### PR TITLE
Add invariant class

### DIFF
--- a/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
@@ -1,0 +1,46 @@
+package edu.njit.jerse.daikonplusplus.inv;
+
+import java.util.Objects;
+
+/** Represents a candidate or inferred invariant as a Java-style expression string. */
+public class Invariant {
+
+  /** The actual invariant expression, e.g., "x > 0". */
+  private final String expression;
+
+  /** Whether this invariant has been falsified by dynamic evidence (e.g., a test case). */
+  private boolean falsified;
+
+  /**
+   * Constructs a new invariant with the given expression.
+   *
+   * @param expression Java-style Boolean expression representing the invariant.
+   */
+  public Invariant(String expression) {
+    this.expression = expression;
+  }
+
+  /** Returns the raw expression string. */
+  public String getExpression() {
+    return expression;
+  }
+
+  /** Returns a user-friendly string representation of this invariant. */
+  @Override
+  public String toString() {
+    return expression;
+  }
+
+  /** Equality based on expression content. */
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Invariant other)) return false;
+    return Objects.equals(this.expression, other.expression);
+  }
+
+  /** Hash code based on the expression. */
+  @Override
+  public int hashCode() {
+    return Objects.hash(expression);
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
@@ -1,7 +1,6 @@
 package edu.njit.jerse.daikonplusplus.inv;
 
 import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -11,7 +10,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class Invariant {
 
   /** The actual invariant expression, e.g., "x > 0". */
-  private final @NonNull String expression;
+  private final String expression;
 
   /** Whether this invariant has been falsified by dynamic evidence. */
   private boolean falsified = false;
@@ -22,7 +21,7 @@ public class Invariant {
    *
    * @param expression The Java-style Boolean expression representing the invariant.
    */
-  public Invariant(@NonNull String expression) {
+  public Invariant(String expression) {
     this.expression = expression;
   }
 

--- a/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
@@ -1,6 +1,8 @@
 package edu.njit.jerse.daikonplusplus.inv;
 
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents a candidate or inferred invariant as a Java-style expression string, along with its
@@ -9,7 +11,7 @@ import java.util.Objects;
 public class Invariant {
 
   /** The actual invariant expression, e.g., "x > 0". */
-  private final String expression;
+  private final @NonNull String expression;
 
   /** Whether this invariant has been falsified by dynamic evidence. */
   private boolean falsified = false;
@@ -20,7 +22,7 @@ public class Invariant {
    *
    * @param expression The Java-style Boolean expression representing the invariant.
    */
-  public Invariant(String expression) {
+  public Invariant(@NonNull String expression) {
     this.expression = expression;
   }
 
@@ -46,9 +48,14 @@ public class Invariant {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (!(o instanceof edu.njit.jerse.daikonplusplus.inv.Invariant other)) return false;
-    return Objects.equals(this.expression, other.expression) && this.falsified == other.falsified;
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Invariant other)) {
+      return false;
+    }
+    return falsified == other.falsified && Objects.equals(expression, other.expression);
   }
 
   @Override

--- a/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
@@ -12,17 +12,16 @@ public class Invariant {
   private final String expression;
 
   /** Whether this invariant has been falsified by dynamic evidence. */
-  private boolean falsified;
+  private boolean falsified = false;
 
   /**
-   * Constructs a new invariant with the given expression. By default, it is assumed to be valid
-   * (not falsified).
+   * Constructs a new invariant with the given expression. The invariant is initially not marked as
+   * falsified.
    *
    * @param expression The Java-style Boolean expression representing the invariant.
    */
   public Invariant(String expression) {
     this.expression = expression;
-    this.falsified = false;
   }
 
   /** Returns the invariant expression string. */
@@ -40,11 +39,6 @@ public class Invariant {
     this.falsified = true;
   }
 
-  /** Clears the falsified flag (i.e., marks it as valid again). */
-  public void resetFalsified() {
-    this.falsified = false;
-  }
-
   /** Returns a string representation (with optional status). */
   @Override
   public String toString() {
@@ -53,7 +47,7 @@ public class Invariant {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Invariant other)) return false;
+    if (!(o instanceof edu.njit.jerse.daikonplusplus.inv.Invariant other)) return false;
     return Objects.equals(this.expression, other.expression) && this.falsified == other.falsified;
   }
 

--- a/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/inv/Invariant.java
@@ -2,45 +2,63 @@ package edu.njit.jerse.daikonplusplus.inv;
 
 import java.util.Objects;
 
-/** Represents a candidate or inferred invariant as a Java-style expression string. */
+/**
+ * Represents a candidate or inferred invariant as a Java-style expression string, along with its
+ * validation status.
+ */
 public class Invariant {
 
   /** The actual invariant expression, e.g., "x > 0". */
   private final String expression;
 
-  /** Whether this invariant has been falsified by dynamic evidence (e.g., a test case). */
+  /** Whether this invariant has been falsified by dynamic evidence. */
   private boolean falsified;
 
   /**
-   * Constructs a new invariant with the given expression.
+   * Constructs a new invariant with the given expression. By default, it is assumed to be valid
+   * (not falsified).
    *
-   * @param expression Java-style Boolean expression representing the invariant.
+   * @param expression The Java-style Boolean expression representing the invariant.
    */
   public Invariant(String expression) {
     this.expression = expression;
+    this.falsified = false;
   }
 
-  /** Returns the raw expression string. */
+  /** Returns the invariant expression string. */
   public String getExpression() {
     return expression;
   }
 
-  /** Returns a user-friendly string representation of this invariant. */
-  @Override
-  public String toString() {
-    return expression;
+  /** Returns whether this invariant has been falsified. */
+  public boolean isFalsified() {
+    return falsified;
   }
 
-  /** Equality based on expression content. */
+  /** Marks this invariant as falsified. */
+  public void markFalsified() {
+    this.falsified = true;
+  }
+
+  /** Clears the falsified flag (i.e., marks it as valid again). */
+  public void resetFalsified() {
+    this.falsified = false;
+  }
+
+  /** Returns a string representation (with optional status). */
+  @Override
+  public String toString() {
+    return expression + (falsified ? "  [FALSIFIED]" : "");
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof Invariant other)) return false;
-    return Objects.equals(this.expression, other.expression);
+    return Objects.equals(this.expression, other.expression) && this.falsified == other.falsified;
   }
 
-  /** Hash code based on the expression. */
   @Override
   public int hashCode() {
-    return Objects.hash(expression);
+    return Objects.hash(expression, falsified);
   }
 }


### PR DESCRIPTION
This PR introduces the new `edu.njit.jerse.daikonplusplus.inv` package and defines a minimal `Invariant` class used to represent candidate invariants as string expressions. This class will be used by `ProgramPoint` objects to store invariants throughout the system.