### PR TITLE
Add program structure and program point packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     checkerFramework 'org.checkerframework:checker:3.49.5'
     compileOnly 'org.checkerframework:checker-qual:3.49.5'
+    implementation 'com.github.javaparser:javaparser-core:3.26.2'
 }
 
 test {

--- a/src/main/java/edu/njit/jerse/daikonplusplus/pp/ProgramPoint.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/pp/ProgramPoint.java
@@ -1,0 +1,32 @@
+package edu.njit.jerse.daikonplusplus.pp;
+
+import edu.njit.jerse.daikonplusplus.inv.Invariant;
+import edu.njit.jerse.daikonplusplus.structure.ProgramStructureElement;
+import java.util.List;
+
+/**
+ * Represents a specific semantic point in the program where invariants may be inferred or checked.
+ */
+public interface ProgramPoint {
+
+  /** The parent program structure element this point belongs to. */
+  ProgramStructureElement getParentElement();
+
+  /** The kind of this program point (e.g., METHOD_ENTRY, LOOP_HEADER). */
+  ProgramPointKind getKind();
+
+  /** Unique ID for this program point (e.g., elementUniqueId + kind + line). */
+  String getUniqueId();
+
+  /** Line number in the file where this point occurs. */
+  int getLineNumber();
+
+  /** Path to the file containing this program point. */
+  String getFilePath();
+
+  /** Variables visible at this point (e.g., method parameters, fields, locals). */
+  List<VariableInfo> getVisibleVariables();
+
+  /** Invariants associated with this point. */
+  List<Invariant> getInvariants();
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/pp/ProgramPointImpl.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/pp/ProgramPointImpl.java
@@ -1,0 +1,92 @@
+package edu.njit.jerse.daikonplusplus.pp;
+
+import edu.njit.jerse.daikonplusplus.inv.Invariant;
+import edu.njit.jerse.daikonplusplus.structure.ProgramStructureElement;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.checkerframework.checker.initialization.qual.UnderInitialization;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.RequiresNonNull;
+
+/** Concrete implementation of a program point. */
+public class ProgramPointImpl implements ProgramPoint {
+
+  private final ProgramStructureElement parent;
+  private final ProgramPointKind kind;
+  private final int lineNumber;
+  private final List<VariableInfo> visibleVariables;
+  private final List<Invariant> invariants;
+  private final String uniqueId;
+
+  public ProgramPointImpl(
+      ProgramStructureElement parent,
+      ProgramPointKind kind,
+      int lineNumber,
+      List<VariableInfo> visibleVariables,
+      List<Invariant> invariants) {
+    this.parent = parent;
+    this.kind = kind;
+    this.lineNumber = lineNumber;
+    this.visibleVariables = visibleVariables;
+    this.invariants = invariants;
+    this.uniqueId = computeUniqueId();
+  }
+
+  @RequiresNonNull({"parent", "kind"})
+  private String computeUniqueId(@UnderInitialization ProgramPointImpl this) {
+    return parent.getUniqueId() + ":::" + kind.name() + "@L" + lineNumber;
+  }
+
+  @Override
+  public ProgramStructureElement getParentElement() {
+    return parent;
+  }
+
+  @Override
+  public ProgramPointKind getKind() {
+    return kind;
+  }
+
+  @Override
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  @Override
+  public int getLineNumber() {
+    return lineNumber;
+  }
+
+  @Override
+  public String getFilePath() {
+    return parent.getFilePath();
+  }
+
+  @Override
+  public List<VariableInfo> getVisibleVariables() {
+    return Collections.unmodifiableList(visibleVariables);
+  }
+
+  @Override
+  public List<Invariant> getInvariants() {
+    return Collections.unmodifiableList(invariants);
+  }
+
+  @Override
+  public String toString() {
+    return kind + " @ " + parent.getFullyQualifiedName() + " line " + lineNumber;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ProgramPointImpl other)) return false;
+    return Objects.equals(this.uniqueId, other.uniqueId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uniqueId);
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/pp/ProgramPointKind.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/pp/ProgramPointKind.java
@@ -1,0 +1,20 @@
+package edu.njit.jerse.daikonplusplus.pp;
+
+public enum ProgramPointKind {
+  METHOD_ENTRY,
+  METHOD_EXIT,
+  CONSTRUCTOR_ENTRY,
+  CONSTRUCTOR_EXIT,
+  LOOP_HEADER_ENTRY,
+  LOOP_HEADER_EXIT,
+  LOOP_BODY_ENTRY,
+  LOOP_BODY_EXIT,
+  STATIC_BLOCK_ENTRY,
+  STATIC_BLOCK_EXIT,
+  LAMBDA_ENTRY,
+  LAMBDA_EXIT,
+  IF_CONDITION, // condition check only
+  FIELD_READ, // field get
+  FIELD_WRITE, // field set
+  CUSTOM
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/pp/VariableInfo.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/pp/VariableInfo.java
@@ -1,0 +1,25 @@
+package edu.njit.jerse.daikonplusplus.pp;
+
+/** Represents a variable visible at a program point. */
+public class VariableInfo {
+  private final String name;
+  private final String type;
+
+  public VariableInfo(String name, String type) {
+    this.name = name;
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    return type + " " + name;
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/ClassElement.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/ClassElement.java
@@ -1,0 +1,23 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+/** Represents a class, interface, or enum in the program structure hierarchy. */
+public class ClassElement extends ProgramStructureElement {
+
+  /**
+   * Constructs a new class element.
+   *
+   * @param simpleName The class's simple (unqualified) name.
+   * @param parent The package or outer class containing this class.
+   * @param filePath Path to the file where the class is declared.
+   * @param startLine The line where the class declaration begins.
+   * @param endLine The line where the class declaration ends.
+   */
+  public ClassElement(
+      String simpleName,
+      ProgramStructureElement parent,
+      String filePath,
+      int startLine,
+      int endLine) {
+    super(simpleName, ProgramElementType.CLASS, parent, filePath, startLine, endLine, null);
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/ConstructorElement.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/ConstructorElement.java
@@ -1,0 +1,52 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+import java.util.List;
+
+/**
+ * Represents a constructor in the program structure hierarchy. Stores the parameter types for
+ * signature generation.
+ */
+public class ConstructorElement extends ProgramStructureElement {
+
+  /** The parameter types of the constructor. */
+  private final List<String> paramTypes;
+
+  /**
+   * Constructs a new constructor element.
+   *
+   * @param simpleName The constructor's name (usually matches class name).
+   * @param paramTypes The fully qualified types of each parameter.
+   * @param parent The class containing this constructor.
+   * @param filePath Path to the file where the constructor is declared.
+   * @param startLine The line where the constructor declaration begins.
+   * @param endLine The line where the constructor declaration ends.
+   */
+  public ConstructorElement(
+      String simpleName,
+      List<String> paramTypes,
+      ProgramStructureElement parent,
+      String filePath,
+      int startLine,
+      int endLine) {
+    super(
+        simpleName,
+        ProgramElementType.CONSTRUCTOR,
+        parent,
+        filePath,
+        startLine,
+        endLine,
+        buildSig(paramTypes)); // pass signature for uniqueId
+    this.paramTypes = paramTypes;
+  }
+
+  /** Builds a signature string like {@code (int,String)} for uniqueId. */
+  private static String buildSig(List<String> params) {
+    String joined = (params == null || params.isEmpty()) ? "" : String.join(",", params);
+    return "(" + joined + ")";
+  }
+
+  /** Returns the list of parameter types. */
+  public List<String> getParamTypes() {
+    return paramTypes;
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/FieldElement.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/FieldElement.java
@@ -1,0 +1,34 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+/** Represents a field in the program structure hierarchy. */
+public class FieldElement extends ProgramStructureElement {
+
+  /** The type of the field. */
+  private final String fieldType;
+
+  /**
+   * Constructs a new field element.
+   *
+   * @param name The field name.
+   * @param fieldType The fully qualified type of the field.
+   * @param parent The class containing this field.
+   * @param filePath Path to the file where the field is declared.
+   * @param startLine The line where the field declaration begins.
+   * @param endLine The line where the field declaration ends.
+   */
+  public FieldElement(
+      String name,
+      String fieldType,
+      ProgramStructureElement parent,
+      String filePath,
+      int startLine,
+      int endLine) {
+    super(name, ProgramElementType.FIELD, parent, filePath, startLine, endLine, null);
+    this.fieldType = fieldType;
+  }
+
+  /** Returns the type of the field. */
+  public String getFieldType() {
+    return fieldType;
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/MethodElement.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/MethodElement.java
@@ -1,0 +1,63 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+import java.util.List;
+
+/**
+ * Represents a method in the program structure hierarchy. Stores the return type and parameter
+ * types for signature generation.
+ */
+public class MethodElement extends ProgramStructureElement {
+
+  /** The return type of the method. */
+  private final String returnType;
+
+  /** The parameter types of the method. */
+  private final List<String> paramTypes;
+
+  /**
+   * Constructs a new method element.
+   *
+   * @param simpleName The method's simple name.
+   * @param returnType The return type of the method.
+   * @param paramTypes The fully qualified types of each parameter.
+   * @param parent The class or interface containing this method.
+   * @param filePath Path to the file where the method is declared.
+   * @param startLine The line where the method declaration begins.
+   * @param endLine The line where the method declaration ends.
+   */
+  public MethodElement(
+      String simpleName,
+      String returnType,
+      List<String> paramTypes,
+      ProgramStructureElement parent,
+      String filePath,
+      int startLine,
+      int endLine) {
+    super(
+        simpleName,
+        ProgramElementType.METHOD,
+        parent,
+        filePath,
+        startLine,
+        endLine,
+        buildSig(returnType, paramTypes)); // pass signature for uniqueId
+    this.returnType = returnType;
+    this.paramTypes = paramTypes;
+  }
+
+  /** Builds a signature string like {@code void(int,String)} for uniqueId. */
+  private static String buildSig(String returnType, List<String> params) {
+    String joined = (params == null || params.isEmpty()) ? "" : String.join(",", params);
+    return returnType + "(" + joined + ")";
+  }
+
+  /** Returns the return type of this method. */
+  public String getReturnType() {
+    return returnType;
+  }
+
+  /** Returns the list of parameter types. */
+  public List<String> getParamTypes() {
+    return paramTypes;
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/PackageElement.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/PackageElement.java
@@ -1,0 +1,21 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+/** Represents a package in the program structure hierarchy. */
+public class PackageElement extends ProgramStructureElement {
+
+  /**
+   * Constructs a new package element.
+   *
+   * @param packageName The package's qualified name, or an empty string for the default package.
+   */
+  public PackageElement(String packageName) {
+    super(
+        packageName == null ? "" : packageName,
+        ProgramElementType.PACKAGE,
+        null,
+        "<package:" + (packageName == null ? "" : packageName) + ">",
+        -1,
+        -1,
+        null);
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/Program.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/Program.java
@@ -1,0 +1,74 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Represents a complete Java program or compilation unit under analysis. Contains top-level program
+ * structure elements such as classes or interfaces.
+ */
+public class Program {
+
+  private final List<ProgramStructureElement> topLevelElements;
+  private final String name;
+
+  public Program(String name) {
+    this.name = name;
+    this.topLevelElements = new ArrayList<>();
+  }
+
+  public void addTopLevelElement(ProgramStructureElement element) {
+    topLevelElements.add(element);
+  }
+
+  public List<ProgramStructureElement> getTopLevelElements() {
+    return Collections.unmodifiableList(topLevelElements);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Optional<ProgramStructureElement> findByUniqueId(String uniqueId) {
+    for (ProgramStructureElement element : topLevelElements) {
+      Optional<ProgramStructureElement> match = findRecursive(element, uniqueId);
+      if (match.isPresent()) return match;
+    }
+    return Optional.empty();
+  }
+
+  private Optional<ProgramStructureElement> findRecursive(
+      ProgramStructureElement current, String uniqueId) {
+    if (current.getUniqueId().equals(uniqueId)) {
+      return Optional.of(current);
+    }
+    for (ProgramStructureElement child : current.getChildren()) {
+      Optional<ProgramStructureElement> result = findRecursive(child, uniqueId);
+      if (result.isPresent()) return result;
+    }
+    return Optional.empty();
+  }
+
+  public List<ProgramStructureElement> getAllElements() {
+    List<ProgramStructureElement> all = new ArrayList<>();
+    for (ProgramStructureElement top : topLevelElements) {
+      collectRecursive(top, all);
+    }
+    return all;
+  }
+
+  private void collectRecursive(
+      ProgramStructureElement current, List<ProgramStructureElement> acc) {
+    acc.add(current);
+    for (ProgramStructureElement child : current.getChildren()) {
+      collectRecursive(child, acc);
+    }
+  }
+
+  // ==========================
+  //  Factory Methods
+  // ==========================
+
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/ProgramElementType.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/ProgramElementType.java
@@ -1,0 +1,15 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+public enum ProgramElementType {
+  PACKAGE,
+  CLASS,
+  INTERFACE,
+  ENUM,
+  METHOD,
+  CONSTRUCTOR,
+  FIELD,
+  STATIC_BLOCK,
+  LAMBDA,
+  BLOCK,
+  CUSTOM
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/ProgramLoader.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/ProgramLoader.java
@@ -1,0 +1,179 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithRange;
+import com.github.javaparser.ast.type.Type;
+import edu.njit.jerse.daikonplusplus.pp.ProgramPoint;
+import edu.njit.jerse.daikonplusplus.pp.ProgramPointImpl;
+import edu.njit.jerse.daikonplusplus.pp.ProgramPointKind;
+import edu.njit.jerse.daikonplusplus.pp.VariableInfo;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+/**
+ * Utility class for parsing Java source files and building the program structure hierarchy.
+ *
+ * <p>Uses JavaParser to extract packages, classes, fields, methods, and constructors, and generates
+ * {@link ProgramPoint} objects for key locations like method entry and exit.
+ */
+public class ProgramLoader {
+
+  /** Shared JavaParser instance. */
+  private final JavaParser parser;
+
+  /** Cache for package elements to avoid duplicates across files. */
+  private final Map<String, PackageElement> packageCache = new HashMap<>();
+
+  /** Constructs a new ProgramLoader with default parser settings. */
+  public ProgramLoader() {
+    this.parser = new JavaParser(new ParserConfiguration());
+  }
+
+  /**
+   * Loads a program model from a list of source file paths.
+   *
+   * @param programName Name to assign to the loaded program.
+   * @param sourceFiles List of paths to Java source files.
+   * @return A {@link Program} object representing the loaded structure.
+   * @throws IOException if any file cannot be read or parsed.
+   */
+  public Program load(String programName, List<Path> sourceFiles) throws IOException {
+    Program program = new Program(programName);
+
+    for (Path p : sourceFiles) {
+      if (!Files.isRegularFile(p)) continue;
+
+      CompilationUnit cu =
+          parser.parse(p).getResult().orElseThrow(() -> new IOException("Parse failed for " + p));
+
+      String pkgName = cu.getPackageDeclaration().map(pd -> pd.getName().asString()).orElse("");
+      PackageElement pkgElt = packageCache.computeIfAbsent(pkgName, PackageElement::new);
+      if (!program.getTopLevelElements().contains(pkgElt)) {
+        program.addTopLevelElement(pkgElt);
+      }
+
+      // Handle classes/interfaces
+      cu.findAll(ClassOrInterfaceDeclaration.class)
+          .forEach(
+              td -> {
+                createClassLike(td, pkgElt, p);
+              });
+
+      // Handle enums
+      cu.findAll(EnumDeclaration.class)
+          .forEach(
+              td -> {
+                createClassLike(td, pkgElt, p);
+              });
+    }
+
+    return program;
+  }
+
+  /** Creates a ClassElement (for class/interface/enum) and processes its members. */
+  private void createClassLike(TypeDeclaration<?> td, PackageElement pkgElt, Path file) {
+    String className = td.getNameAsString();
+    int start = startLine(td);
+    int end = endLine(td);
+    ClassElement cls = new ClassElement(className, pkgElt, file.toString(), start, end);
+
+    // Iterate members with explicit typing to avoid raw/erased inference issues.
+    for (BodyDeclaration<?> member : td.getMembers()) {
+      if (member.isFieldDeclaration()) {
+        createFields(member.asFieldDeclaration(), cls, file);
+      } else if (member.isConstructorDeclaration()) {
+        createConstructor(member.asConstructorDeclaration(), cls, file);
+      } else if (member.isMethodDeclaration()) {
+        createMethod(member.asMethodDeclaration(), cls, file);
+      }
+    }
+  }
+
+  /** Creates field elements from a JavaParser {@link FieldDeclaration}. */
+  private void createFields(FieldDeclaration fd, ClassElement parent, Path file) {
+    int start = startLine(fd);
+    int end = endLine(fd);
+    String type = fd.getElementType().asString();
+    fd.getVariables()
+        .forEach(
+            var -> {
+              new FieldElement(var.getNameAsString(), type, parent, file.toString(), start, end);
+            });
+  }
+
+  /** Creates a constructor element and its associated program points. */
+  private void createConstructor(ConstructorDeclaration cd, ClassElement parent, Path file) {
+    int start = startLine(cd);
+    int end = endLine(cd);
+    List<String> paramTypes = new ArrayList<>();
+    cd.getParameters().forEach(p -> paramTypes.add(erasedType(p.getType())));
+
+    ConstructorElement ctor =
+        new ConstructorElement(
+            cd.getNameAsString(), paramTypes, parent, file.toString(), start, end);
+
+    List<VariableInfo> params = new ArrayList<>();
+    cd.getParameters()
+        .forEach(p -> params.add(new VariableInfo(p.getNameAsString(), erasedType(p.getType()))));
+
+    ctor.addProgramPoint(
+        new ProgramPointImpl(ctor, ProgramPointKind.CONSTRUCTOR_ENTRY, start, params, List.of()));
+    ctor.addProgramPoint(
+        new ProgramPointImpl(ctor, ProgramPointKind.METHOD_EXIT, end, params, List.of()));
+  }
+
+  /** Creates a method element and its associated program points. */
+  private void createMethod(MethodDeclaration md, ClassElement parent, Path file) {
+    int start = startLine(md);
+    int end = endLine(md);
+    String ret = erasedType(md.getType());
+    List<String> paramTypes = new ArrayList<>();
+    md.getParameters().forEach(p -> paramTypes.add(erasedType(p.getType())));
+
+    MethodElement method =
+        new MethodElement(
+            md.getNameAsString(), ret, paramTypes, parent, file.toString(), start, end);
+
+    List<VariableInfo> params = new ArrayList<>();
+    md.getParameters()
+        .forEach(p -> params.add(new VariableInfo(p.getNameAsString(), erasedType(p.getType()))));
+
+    // METHOD_ENTRY
+    method.addProgramPoint(
+        new ProgramPointImpl(method, ProgramPointKind.METHOD_ENTRY, start, params, List.of()));
+
+    // METHOD_EXIT (+ synthetic 'return' if non-void)
+    List<VariableInfo> exitVars = new ArrayList<>(params);
+    if (!"void".equals(ret)) {
+      exitVars.add(new VariableInfo("return", ret));
+    }
+    method.addProgramPoint(
+        new ProgramPointImpl(method, ProgramPointKind.METHOD_EXIT, end, exitVars, List.of()));
+  }
+
+  /** Returns the erased (simple) type name for a JavaParser {@link Type}. */
+  private static String erasedType(Type t) {
+    return t.asString();
+  }
+
+  /** Returns the starting line for a node, or -1 if unknown. */
+  private static int startLine(NodeWithRange<?> n) {
+    return n.getRange().map(r -> r.begin.line).orElse(-1);
+  }
+
+  /** Returns the ending line for a node, or -1 if unknown. */
+  private static int endLine(NodeWithRange<?> n) {
+    return n.getRange().map(r -> r.end.line).orElse(-1);
+  }
+}

--- a/src/main/java/edu/njit/jerse/daikonplusplus/structure/ProgramStructureElement.java
+++ b/src/main/java/edu/njit/jerse/daikonplusplus/structure/ProgramStructureElement.java
@@ -1,0 +1,221 @@
+package edu.njit.jerse.daikonplusplus.structure;
+
+import edu.njit.jerse.daikonplusplus.pp.ProgramPoint;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.initialization.qual.UnderInitialization;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Represents a structural element in a Java program, such as a class, method, field, or block.
+ * These elements form a tree hierarchy reflecting the program's structure. Each node may contain:
+ *
+ * <ul>
+ *   <li>Other nested structure elements (children)
+ *   <li>Associated program points (e.g., method entry, loop heads) for invariant generation
+ *   <li>Location metadata such as file path and source code line range
+ * </ul>
+ */
+public abstract class ProgramStructureElement {
+
+  /** Local name of the element (e.g., "toString", "MyClass", "count") */
+  protected final String identifier;
+
+  /** Enum value indicating whether this is a class, method, field, etc. */
+  protected final ProgramElementType elementType;
+
+  /** Parent structure element in the hierarchy, or null if this is the root. */
+  protected final @Nullable ProgramStructureElement parent;
+
+  /** Child elements nested within this one (e.g., methods in a class). */
+  protected final List<ProgramStructureElement> children;
+
+  /** Program points associated with this structure element (e.g., method entry, loop heads). */
+  protected final List<ProgramPoint> programPoints;
+
+  /** Path to the source file that defines this element. */
+  protected final String filePath;
+
+  /** Line where the element begins in the source file (inclusive). */
+  protected final int startLine;
+
+  /** Line where the element ends in the source file (inclusive). */
+  protected final int endLine;
+
+  /** Fully qualified name including parent hierarchy (e.g., foo.Bar.toString). */
+  protected final String fullyQualifiedName;
+
+  /** Globally unique ID including file, FQN, type, and optionally a signature. */
+  protected final String uniqueId;
+
+  /**
+   * Constructs a new program structure element.
+   *
+   * @param identifier Short name for this element (e.g., "main", "count").
+   * @param elementType The type of the element (CLASS, METHOD, FIELD, etc.).
+   * @param parent The parent element in the hierarchy, or null if top-level.
+   * @param filePath Path to the source file where this element is defined.
+   * @param startLine Start line in the source file (inclusive).
+   * @param endLine End line in the source file (inclusive).
+   */
+  @SuppressWarnings("initialization")
+  public ProgramStructureElement(
+      String identifier,
+      ProgramElementType elementType,
+      @Nullable ProgramStructureElement parent,
+      String filePath,
+      int startLine,
+      int endLine,
+      @Nullable String signatureForId) {
+    this.identifier = identifier;
+    this.elementType = elementType;
+    this.parent = parent;
+    this.filePath = filePath;
+    this.startLine = startLine;
+    this.endLine = endLine;
+    this.children = new ArrayList<>();
+    this.programPoints = new ArrayList<>();
+
+    this.fullyQualifiedName = computeFullyQualifiedName();
+    this.uniqueId = computeUniqueId(signatureForId);
+
+    if (parent != null) {
+      parent.addChild(this);
+    }
+  }
+
+  /** Returns the local identifier (e.g., "main", "count"). */
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  /** Returns the enum type of this program element (e.g., METHOD, CLASS). */
+  public ProgramElementType getElementType() {
+    return elementType;
+  }
+
+  /** Returns the parent element in the program structure hierarchy, or null if this is the root. */
+  public @Nullable ProgramStructureElement getParent() {
+    return parent;
+  }
+
+  /** Returns an unmodifiable list of all direct children of this structure element. */
+  public List<ProgramStructureElement> getChildren() {
+    return Collections.unmodifiableList(children);
+  }
+
+  /** Returns an unmodifiable list of all program points associated with this element. */
+  public List<ProgramPoint> getProgramPoints() {
+    return Collections.unmodifiableList(programPoints);
+  }
+
+  /** Returns the absolute or project-relative path to the file where this element is defined. */
+  public String getFilePath() {
+    return filePath;
+  }
+
+  /** Returns the line number in the file where this element begins (inclusive). */
+  public int getStartLine() {
+    return startLine;
+  }
+
+  /** Returns the line number in the file where this element ends (inclusive). */
+  public int getEndLine() {
+    return endLine;
+  }
+
+  /**
+   * Returns the fully qualified name of the element, including all parent names. For example:
+   * {@code foo.Bar.toString}
+   */
+  public String getFullyQualifiedName() {
+    return fullyQualifiedName;
+  }
+
+  /**
+   * Returns a globally unique ID for this structure element. This includes file path, fully
+   * qualified name, element type, and (if applicable) a signature. Example: {@code
+   * src/Foo.java#foo.Bar.toString:METHOD:void(String)}
+   */
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  /**
+   * Adds a child structure element to this element.
+   *
+   * @param child The element to add as a child.
+   */
+  public void addChild(@UnderInitialization ProgramStructureElement child) {
+    @SuppressWarnings("cast.unsafe")
+    ProgramStructureElement initChild = (@Initialized ProgramStructureElement) child;
+    children.add(initChild);
+  }
+
+  /**
+   * Adds a program point to this structure element (e.g., method entry or exit).
+   *
+   * @param pp The program point to associate.
+   */
+  public void addProgramPoint(ProgramPoint pp) {
+    programPoints.add(pp);
+  }
+
+  /** Computes the fully qualified name by walking up the parent chain. */
+  protected String computeFullyQualifiedName(@UnderInitialization ProgramStructureElement this) {
+    return (parent != null ? parent.getFullyQualifiedName() + "." : "") + identifier;
+  }
+
+  /**
+   * Computes a globally unique identifier string. This combines file path, fully qualified name,
+   * element type, and an optional signature.
+   */
+  protected String computeUniqueId(
+      @UnderInitialization ProgramStructureElement this, @Nullable String signatureForId) {
+
+    StringBuilder sb = new StringBuilder();
+    sb.append(filePath)
+        .append("#")
+        .append(fullyQualifiedName)
+        .append(":")
+        .append(String.valueOf(elementType)); // no dereference here
+
+    if (signatureForId != null && !signatureForId.isEmpty()) {
+      sb.append(":").append(signatureForId);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Returns a method or constructor signature (e.g., {@code void(String)}). By default, returns an
+   * empty string. Subclasses should override as needed.
+   */
+  protected String getSignature() {
+    return "";
+  }
+
+  /**
+   * Returns a human-readable string including type, fully qualified name, and source line range.
+   */
+  @Override
+  public String toString() {
+    return elementType + ": " + fullyQualifiedName + " [" + startLine + "-" + endLine + "]";
+  }
+
+  /** Checks equality based on the unique ID of the structure element. */
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ProgramStructureElement other)) return false;
+    return Objects.equals(this.uniqueId, other.uniqueId);
+  }
+
+  /** Returns a hash code based on the unique ID. */
+  @Override
+  public int hashCode() {
+    return Objects.hash(uniqueId);
+  }
+}


### PR DESCRIPTION
This PR adds two core packages  (i.e., `structure` and `pp`, which are dependent on each other) which, together with the existing `inv` package, form the foundation for representing programs, locating analysis points, and associating invariants. 

**Main goal:** To provide **a navigable tree of program elements** and stable **anchors for invariants**.

Packages:
- **`structure`**  
  Defines `ProgramStructureElement` (and subclasses) to represent the hierarchical program structure (package → class → method/field/constructor), with metadata such as identifiers, parents/children, source location, and `uniqueId`s.

- **`pp` (Program Points)**  
  Defines `ProgramPoint` and `ProgramPointImpl` to represent specific locations inside a structure element, with `ProgramPointKind` (e.g., METHOD_ENTRY), line number, visible variables, and associated invariants.

- **`inv`**  (previously added)
  Contains `Invariant` objects representing boolean conditions, plus a `falsified` flag.

Conceptual Model:
```text
Program
└─ PackageElement
   └─ ClassElement
      ├─ MethodElement
      │  ├─ ProgramPointImpl (METHOD_ENTRY)
      │  │  ├─ Invariant(expression="x > 0", falsified=false)
      │  │  └─ Invariant(expression="y != null", falsified=true)
      │  └─ ProgramPointImpl (METHOD_EXIT)
      │     └─ Invariant(expression="result >= 0", falsified=false)
      └─ ConstructorElement
         ├─ ProgramPointImpl (CONSTRUCTOR_ENTRY)
         │  └─ Invariant(...)
         └─ ProgramPointImpl (CONSTRUCTOR_EXIT)
            └─ Invariant(...)

